### PR TITLE
Fix turboress and add turboress to full hp

### DIFF
--- a/dist/scripts.js
+++ b/dist/scripts.js
@@ -2416,8 +2416,12 @@ function travelBook(selection) {
     if (selection === void 0) { selection = PortBookOptionsEnum.kop; }
     Scripts.Port.travelBook(selection);
 }
-function turboRess() {
-    Scripts.Common.turboRess();
+function turboRess(bandageAfterRess) {
+    if (bandageAfterRess === void 0) { bandageAfterRess = false; }
+    Scripts.Common.turboRess(bandageAfterRess);
+}
+function turboRessFull() {
+    Scripts.Common.turboRessFull();
 }
 function unlock() {
     Scripts.Lockpicking.unlock();
@@ -2913,14 +2917,41 @@ var Scripts;
             }
             Orion.OpenContainer('openContainer');
         };
-        Common.turboRess = function () {
-            var serialGhost = Orion.FindType('1', '-1', 'ground', "human|fast|dead", 1);
-            if (!serialGhost.length) {
-                Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
+        Common.turboRess = function (bandageAfterRess) {
+            if (bandageAfterRess === void 0) { bandageAfterRess = false; }
+            var closestGhosts = Orion.FindType(-1, -1, 'ground', 'human|dead|fast', 1);
+            if ((closestGhosts === null || closestGhosts === void 0 ? void 0 : closestGhosts.length) < 1) {
+                return Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
+            }
+            Orion.WaitTargetObject(closestGhosts[0]);
+            Orion.UseType(gameObject.uncategorized.bandy.graphic);
+            Orion.Wait(100);
+            if (bandageAfterRess) {
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.bandy.graphic);
+            }
+        };
+        Common.turboRessFull = function () {
+            var closestGhosts = Orion.FindType(-1, -1, 'ground', 'human|dead|fast', 1);
+            if ((closestGhosts === null || closestGhosts === void 0 ? void 0 : closestGhosts.length) < 1) {
+                return Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
+            }
+            if (Orion.Count(gameObject.uncategorized.krvavaBanda1.graphic) >= 30) {
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.krvavaBanda1.graphic);
+                Orion.Wait(100);
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.bandy.graphic);
+            }
+            else if (Orion.Count(gameObject.uncategorized.krvavaBanda2.graphic) >= 30) {
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.krvavaBanda2.graphic);
+                Orion.Wait(100);
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.bandy.graphic);
             }
             else {
-                Orion.WaitTargetObject(serialGhost[0]);
-                Orion.UseType(gameObject.uncategorized.bandy.graphic);
+                Scripts.Common.turboRess(true);
             }
         };
         return Common;

--- a/dist/scripts.js
+++ b/dist/scripts.js
@@ -2932,20 +2932,23 @@ var Scripts;
             }
         };
         Common.turboRessFull = function () {
+            var getBloodyBandageGraphic = function () {
+                if (Orion.Count(gameObject.uncategorized.krvavaBanda1.graphic) >= 30) {
+                    return gameObject.uncategorized.krvavaBanda1.graphic;
+                }
+                else if (Orion.Count(gameObject.uncategorized.krvavaBanda2.graphic) >= 30) {
+                    return gameObject.uncategorized.krvavaBanda2.graphic;
+                }
+                return null;
+            };
             var closestGhosts = Orion.FindType(-1, -1, 'ground', 'human|dead|fast', 1);
             if ((closestGhosts === null || closestGhosts === void 0 ? void 0 : closestGhosts.length) < 1) {
                 return Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
             }
-            if (Orion.Count(gameObject.uncategorized.krvavaBanda1.graphic) >= 30) {
+            var bloodyBandageGraphic = getBloodyBandageGraphic();
+            if (bloodyBandageGraphic) {
                 Orion.WaitTargetObject(closestGhosts[0]);
-                Orion.UseType(gameObject.uncategorized.krvavaBanda1.graphic);
-                Orion.Wait(100);
-                Orion.WaitTargetObject(closestGhosts[0]);
-                Orion.UseType(gameObject.uncategorized.bandy.graphic);
-            }
-            else if (Orion.Count(gameObject.uncategorized.krvavaBanda2.graphic) >= 30) {
-                Orion.WaitTargetObject(closestGhosts[0]);
-                Orion.UseType(gameObject.uncategorized.krvavaBanda2.graphic);
+                Orion.UseType(bloodyBandageGraphic);
                 Orion.Wait(100);
                 Orion.WaitTargetObject(closestGhosts[0]);
                 Orion.UseType(gameObject.uncategorized.bandy.graphic);

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -721,10 +721,19 @@ function travelBook(selection = PortBookOptionsEnum.kop) {
 
 /**
  * Ozivi ducha v okruhu 1 policka
+ * @param bandageAfterRess {boolean} ci ma hned po resse hodit bandu na target
  * @example external code `turboRess()`
  */
-function turboRess() {
-    Scripts.Common.turboRess();
+function turboRess(bandageAfterRess = false) {
+    Scripts.Common.turboRess(bandageAfterRess);
+}
+
+/**
+ * Ozivi ducha v okruhu 1 policka do plnych hp (krvavou bandou - Medic)
+ * @example external code `turboRessFull()`
+ */
+function turboRessFull() {
+    Scripts.Common.turboRessFull();
 }
 
 /**

--- a/src/scripts/common.ts
+++ b/src/scripts/common.ts
@@ -368,7 +368,7 @@ namespace Scripts {
         static turboRess(bandageAfterRess = false) {
             const closestGhosts = Orion.FindType(-1, -1, 'ground', 'human|dead|fast', 1);
             if (closestGhosts?.length < 1) {
-                Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
+                return Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
             }
             
             Orion.WaitTargetObject(closestGhosts[0]);
@@ -383,7 +383,7 @@ namespace Scripts {
         static turboRessFull() {
             const closestGhosts = Orion.FindType(-1, -1, 'ground', 'human|dead|fast', 1);
             if (closestGhosts?.length < 1) {
-                Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
+                return Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
             }
             
             if (Orion.Count(gameObject.uncategorized.krvavaBanda1.graphic) >= 30) {

--- a/src/scripts/common.ts
+++ b/src/scripts/common.ts
@@ -365,14 +365,41 @@ namespace Scripts {
             Orion.OpenContainer('openContainer');
         }
 
-        static turboRess() {
-            var serialGhost = Orion.FindType('1', '-1', 'ground', "human|fast|dead",1)
-            if (!serialGhost.length) {
+        static turboRess(bandageAfterRess = false) {
+            const closestGhosts = Orion.FindType(-1, -1, 'ground', 'human|dead|fast', 1);
+            if (closestGhosts?.length < 1) {
                 Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
             }
-            else {
-                Orion.WaitTargetObject(serialGhost[0]);
+            
+            Orion.WaitTargetObject(closestGhosts[0]);
+            Orion.UseType(gameObject.uncategorized.bandy.graphic);
+            Orion.Wait(100);
+            if (bandageAfterRess) {
+                Orion.WaitTargetObject(closestGhosts[0]);
                 Orion.UseType(gameObject.uncategorized.bandy.graphic);
+            }
+        }
+
+        static turboRessFull() {
+            const closestGhosts = Orion.FindType(-1, -1, 'ground', 'human|dead|fast', 1);
+            if (closestGhosts?.length < 1) {
+                Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
+            }
+            
+            if (Orion.Count(gameObject.uncategorized.krvavaBanda1.graphic) >= 30) {
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.krvavaBanda1.graphic);
+                Orion.Wait(100);
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.bandy.graphic);
+            } else if (Orion.Count(gameObject.uncategorized.krvavaBanda2.graphic) >= 30) {
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.krvavaBanda2.graphic);
+                Orion.Wait(100);
+                Orion.WaitTargetObject(closestGhosts[0]);
+                Orion.UseType(gameObject.uncategorized.bandy.graphic);
+            } else {
+                Scripts.Common.turboRess(true)
             }
         }
     }

--- a/src/scripts/common.ts
+++ b/src/scripts/common.ts
@@ -381,20 +381,25 @@ namespace Scripts {
         }
 
         static turboRessFull() {
+            const getBloodyBandageGraphic = () => {
+                if (Orion.Count(gameObject.uncategorized.krvavaBanda1.graphic) >= 30) {
+                    return gameObject.uncategorized.krvavaBanda1.graphic;
+                } else if (Orion.Count(gameObject.uncategorized.krvavaBanda2.graphic) >= 30) {
+                    return gameObject.uncategorized.krvavaBanda2.graphic;
+                }
+
+                return null
+            }
+
             const closestGhosts = Orion.FindType(-1, -1, 'ground', 'human|dead|fast', 1);
             if (closestGhosts?.length < 1) {
                 return Scripts.Utils.playerPrint('Nevidis zadneho ducha k oziveni');
             }
             
-            if (Orion.Count(gameObject.uncategorized.krvavaBanda1.graphic) >= 30) {
+            const bloodyBandageGraphic = getBloodyBandageGraphic();
+            if (bloodyBandageGraphic) {
                 Orion.WaitTargetObject(closestGhosts[0]);
-                Orion.UseType(gameObject.uncategorized.krvavaBanda1.graphic);
-                Orion.Wait(100);
-                Orion.WaitTargetObject(closestGhosts[0]);
-                Orion.UseType(gameObject.uncategorized.bandy.graphic);
-            } else if (Orion.Count(gameObject.uncategorized.krvavaBanda2.graphic) >= 30) {
-                Orion.WaitTargetObject(closestGhosts[0]);
-                Orion.UseType(gameObject.uncategorized.krvavaBanda2.graphic);
+                Orion.UseType(bloodyBandageGraphic);
                 Orion.Wait(100);
                 Orion.WaitTargetObject(closestGhosts[0]);
                 Orion.UseType(gameObject.uncategorized.bandy.graphic);


### PR DESCRIPTION
Fix turboressu

- Pridaná nová option `bandageAfterRess`, ktorá hneď po resse hodí ďalšiu bandu na target (tzn hodí dve bandy, jedna resne, jedna začne healovať). Vhodné napr pre Medika, nakoľko hneď po resse target dostane Flam + Prot
- Pridaný `turboRessFull`, ktorý ressuje krvavými bandami (Medic) do full HP + hodí ďalšiu bandu hneď po resse