### PR TITLE
Loot enhancements

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -22,8 +22,20 @@ declare function cestovniKniha(selection?: PortBookOptionsEnum): void;
 declare function cleanObjectInBag(object: any, objectName?: string): void;
 declare function craftNext(): void;
 declare function craftSelect(): void;
-declare function drink(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, displayTimers?: boolean, refillEmptyLimit?: number, displayInvisLongTimer?: boolean): void;
-declare function drinkFill(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, displayTimers?: boolean, refillEmptyLimit?: number, displayInvisLongTimer?: boolean): void;
+declare function drink(
+    potionName: PotionsEnum,
+    switchWarModeWhenNeeded?: boolean,
+    displayTimers?: boolean,
+    refillEmptyLimit?: number,
+    displayInvisLongTimer?: boolean,
+): void;
+declare function drinkFill(
+    potionName: PotionsEnum,
+    switchWarModeWhenNeeded?: boolean,
+    displayTimers?: boolean,
+    refillEmptyLimit?: number,
+    displayInvisLongTimer?: boolean,
+): void;
 declare function drum(target?: TargetEnum): void;
 declare function ef(self?: boolean, scroll?: boolean, timer?: number): void;
 declare function enemy(): void;
@@ -74,8 +86,18 @@ declare function statusBar(): void;
 declare function summon(creature: string, target?: TargetEnum): void;
 declare function taming(allAround?: boolean, opts?: ITamingOptions): void;
 declare function tamingTrain(robeOfDruids?: boolean): void;
-declare function targetNext(timeToStorePreviousTargets?: number, additionalFlags?: FlagsEnum[], notoriety?: NotorietyEnum[], opts?: ITargetNextOpts): void;
-declare function targetPrevious(timeToStorePreviousTargets?: number, additionalFlags?: string[], notoriety?: string[], opts?: ITargetNextOpts): void;
+declare function targetNext(
+    timeToStorePreviousTargets?: number,
+    additionalFlags?: FlagsEnum[],
+    notoriety?: NotorietyEnum[],
+    opts?: ITargetNextOpts,
+): void;
+declare function targetPrevious(
+    timeToStorePreviousTargets?: number,
+    additionalFlags?: string[],
+    notoriety?: string[],
+    opts?: ITargetNextOpts,
+): void;
 declare function terminateAll(): void;
 declare function tracking(who?: string): void;
 declare function travelBook(selection?: PortBookOptionsEnum): void;
@@ -103,17 +125,41 @@ declare function parseParam(param: any): any;
 declare namespace Scripts {
     class Auto {
         static lagProtection(enemy: GameObject, run?: number): void;
-        static getToDistanceIfNeeded(enemy: GameObject, distance?: number, run?: number, maxWalkingTime?: number): boolean;
-        static killObject(serialToKill: string, poisonTrain?: boolean, waitUntilDead?: boolean, kill?: boolean, distance?: number, lagProtection?: boolean): void;
+        static getToDistanceIfNeeded(
+            enemy: GameObject,
+            distance?: number,
+            run?: number,
+            maxWalkingTime?: number,
+        ): boolean;
+        static killObject(
+            serialToKill: string,
+            poisonTrain?: boolean,
+            waitUntilDead?: boolean,
+            kill?: boolean,
+            distance?: number,
+            lagProtection?: boolean,
+        ): void;
     }
 }
 declare namespace Scripts {
     class Clean {
         static cleanBag(): void;
         static cleanObjectInBag(object: any, objectName?: string): void;
-        static cleanObjectInBagCoord(object: any, objectName?: string, recuseSearch?: boolean, coordinates?: ICoordinates, delta?: number): ICoordinates;
+        static cleanObjectInBagCoord(
+            object: any,
+            objectName?: string,
+            recuseSearch?: boolean,
+            coordinates?: ICoordinates,
+            delta?: number,
+        ): ICoordinates;
         static getSerialsFromMyGameObject(type: IMyGameObject, recuseSearch?: boolean): string[];
-        static cleanMyGameObjectInBag(type: IMyGameObject, tName?: string, recuseSearch?: boolean, coordinates?: ICoordinates, delta?: number): ICoordinates;
+        static cleanMyGameObjectInBag(
+            type: IMyGameObject,
+            tName?: string,
+            recuseSearch?: boolean,
+            coordinates?: ICoordinates,
+            delta?: number,
+        ): ICoordinates;
         static findUniqueGameObjects(object: any): Array<IMyGameObject>;
         static getGameObjectList(object: any): Array<IMyGameObject>;
         static sortBackpackCaleb(): void;
@@ -123,7 +169,11 @@ declare namespace Scripts {
     class Common {
         static svetlo(shouldCast?: boolean): void;
         static shrinkKad(): void;
-        static bandageSelf(minimalCountToWarn?: number, pathToNoBandagesWavFile?: string, failedMessage?: boolean): void;
+        static bandageSelf(
+            minimalCountToWarn?: number,
+            pathToNoBandagesWavFile?: string,
+            failedMessage?: boolean,
+        ): void;
         static massMove(requiredCountInTarget?: number, onlyType?: boolean): void;
         static mysticCounter(): void;
         static hideAll(): void;
@@ -160,13 +210,19 @@ declare namespace Scripts {
         static useKlamak(lvl: number, useAim?: boolean, priorityList?: string[], ignoreSerials?: string[]): void;
     }
 }
+declare const LOOT_BAG = 'loot/bag';
 declare namespace Scripts {
     class Loot {
+        static addLootBag(): number;
         static addCutWeapon(): number;
-        static lootCorpsesAround(cut?: boolean, weapon?: boolean): void;
-        static lootCorpseId(id: string): void;
-        static lootAllFrom(delay?: number): void;
         static carveBody(carveNearestBodyAutomatically?: boolean): void;
+        static corpses(cut?: boolean): void;
+        static lootAllFrom(delay?: number): void;
+        private static lootCorpsesAround;
+        static lootCorpseId(corpseId: string, cut?: boolean, weapon?: boolean): void;
+        private static getBagSnapshot;
+        private static moveLootToLootBag;
+        private static displayLoot;
     }
 }
 declare namespace Scripts {
@@ -210,10 +266,7 @@ declare namespace Scripts {
         static ignoreMyPets(): void;
         static getAvailableNames(): string[];
         static getRandomAvailableName(): string;
-        static savePet(pet: {
-            serial: string;
-            name: string;
-        }): void;
+        static savePet(pet: { serial: string; name: string }): void;
         static getNewPet(): IMyPet | undefined;
         static killTarget(): void;
         static killAll(): void;
@@ -236,10 +289,22 @@ declare namespace Scripts {
         static getEmptyBottle(): string;
         static getKadForPotion(potion: IPotion): string;
         static getMortar(): string;
-        static drinkPotion(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, displayTimers?: boolean, displayInfo?: boolean, refillEmptyLimit?: number, displayInvisLongTimer?: boolean): void;
+        static drinkPotion(
+            potionName: PotionsEnum,
+            switchWarModeWhenNeeded?: boolean,
+            displayTimers?: boolean,
+            displayInfo?: boolean,
+            refillEmptyLimit?: number,
+            displayInvisLongTimer?: boolean,
+        ): void;
         static gmMortar(potionName: PotionsEnum): void;
         static alchemy(potionName: PotionsEnum): void;
-        static fillPotion(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, kadSerial?: string, emptyBottleSerial?: string): void;
+        static fillPotion(
+            potionName: PotionsEnum,
+            switchWarModeWhenNeeded?: boolean,
+            kadSerial?: string,
+            emptyBottleSerial?: string,
+        ): void;
         static potionToKad(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, kadSerial?: string): void;
     }
 }
@@ -272,11 +337,28 @@ declare namespace Scripts {
         static addEnemy(): string;
         static resetFriends(): void;
         static resetEnemies(): void;
-        static targetNext(reverse: boolean, timeToStorePreviousTargets: number, additionalFlags: string[], notoriety: string[], opts: ITargetNextOpts): void;
+        static targetNext(
+            reverse: boolean,
+            timeToStorePreviousTargets: number,
+            additionalFlags: string[],
+            notoriety: string[],
+            opts: ITargetNextOpts,
+        ): void;
         static manualTarget(opts: ITargetNextOpts): void;
-        static highlightEnemy(enemySerial: string, enemy: GameObject, showStatusBar: boolean, targetIndicationEnum: TargetIndicationEnum, statusBarPosition: ICoordinates): void;
+        static highlightEnemy(
+            enemySerial: string,
+            enemy: GameObject,
+            showStatusBar: boolean,
+            targetIndicationEnum: TargetIndicationEnum,
+            statusBarPosition: ICoordinates,
+        ): void;
         static isFriendlyTargetType(graphic: string, color: string, name: string): boolean;
-        static targetNextMonster(reverse: boolean, timeToStorePreviousTargets: number, notoriety: string[], statusWrapperOpt: any): TargetResult;
+        static targetNextMonster(
+            reverse: boolean,
+            timeToStorePreviousTargets: number,
+            notoriety: string[],
+            statusWrapperOpt: any,
+        ): TargetResult;
         static showStatusBarOnWrapper(serial: string, statusWrapperOpt: any): void;
     }
 }
@@ -307,20 +389,46 @@ declare namespace Scripts {
 }
 declare namespace Scripts {
     class Utils {
-        static selectMenu(menuName: string | ISpecialSelection, selections: Array<string | ISpecialSelection>, firstCall?: boolean): void;
+        static selectMenu(
+            menuName: string | ISpecialSelection,
+            selections: Array<string | ISpecialSelection>,
+            firstCall?: boolean,
+        ): void;
         static useAndSelect(serial: string, selections: ISelect[], use?: boolean): void;
-        static refill(obj: IMyGameObject, sourceContainerId: string, quantity?: number, targetContainerId?: string, refillJustWhenIHaveNothing?: boolean, itemName?: string, sourceContainerIsItemOnGround?: boolean): number;
+        static refill(
+            obj: IMyGameObject,
+            sourceContainerId: string,
+            quantity?: number,
+            targetContainerId?: string,
+            refillJustWhenIHaveNothing?: boolean,
+            itemName?: string,
+            sourceContainerIsItemOnGround?: boolean,
+        ): number;
         static getObjSerials(obj: IMyGameObject, container?: string): string[];
         static getColorByNotoriety(notoriety?: number): number;
-        static countObjectInContainer(obj: IMyGameObject, container?: string, containerIsObjItemOnGround?: boolean): number;
+        static countObjectInContainer(
+            obj: IMyGameObject,
+            container?: string,
+            containerIsObjItemOnGround?: boolean,
+        ): number;
         static countItemsBySerials(itemsSerials: string[]): number;
         static moveObjectToContainer(obj: any, fromContainer: string, targetContainer: string): void;
         static moveItems(itemsSerials: string[], targetContainerId: string, quantity: number): number;
-        static waitWhileSomethingInJournal(messages: string[], wait?: number, timeAhead?: number, flags?: string): number;
+        static waitWhileSomethingInJournal(
+            messages: string[],
+            wait?: number,
+            timeAhead?: number,
+            flags?: string,
+        ): number;
         static worldSaveCheckWait(): void;
         static log(message: string, color?: ColorEnum): void;
         static playerPrint(message: string, color?: ColorEnum | number | string, fastPrint?: boolean): void;
-        static charPrint(serial: string, message: string, color?: ColorEnum | number | string, fastPrint?: boolean): void;
+        static charPrint(
+            serial: string,
+            message: string,
+            color?: ColorEnum | number | string,
+            fastPrint?: boolean,
+        ): void;
         static waitTarget(target?: TargetEnum | string): void;
         static resetTimer(timer: string): void;
         static waitWhileTargeting(): void;
@@ -335,15 +443,22 @@ declare namespace Scripts {
         static printColoredHpBar(target: string, percent: number): void;
         static getLivingObjectInDistance(objectSerial: string): GameObject | null;
         static printDamage(serial: string, previousHp: number, force?: boolean): void;
-        static use(val: IMyGameObject | IMyGameObject[], name?: string, minimalCountForWarn?: number, warnWavPath?: string): void;
+        static use(
+            val: IMyGameObject | IMyGameObject[],
+            name?: string,
+            minimalCountForWarn?: number,
+            warnWavPath?: string,
+        ): void;
         static setTargetAlias(targetAliasToSet: string, message?: string): void;
         static findFirstType(myGameObject: IMyGameObject, layer?: number): string | undefined;
         static walkToSerial(serial: string, distance?: number): void;
         static targetObjectNotSelf(objectAlias: string, message?: string): void;
-        static createGameObjectSelections(selections: Array<{
-            ask: string;
-            addObject: string;
-        }>): void;
+        static createGameObjectSelections(
+            selections: Array<{
+                ask: string;
+                addObject: string;
+            }>,
+        ): void;
         static openContainer(s: string, maxWaitingTime?: number): void;
         static isItemStackable(serial: string): boolean;
         static askForCount(): number;
@@ -380,7 +495,12 @@ declare namespace Scripts {
         static makeProgress(): boolean;
         static refOrMake(count: number, resourcePath: string): void;
         static make(count: number, objectAsString: string, setInputs?: boolean): void;
-        static countMaterialForOneItem(objectAsString: string, callStack?: number, count?: number, crafting?: boolean): void;
+        static countMaterialForOneItem(
+            objectAsString: string,
+            callStack?: number,
+            count?: number,
+            crafting?: boolean,
+        ): void;
         static makeFromSelection(): void;
         static listMakeMenu(): void;
         static confirmMakeMenu(): void;
@@ -446,7 +566,11 @@ declare namespace Scripts {
         static harp(targetAlias?: TargetEnum | string): void;
         static lute(targetAlias?: TargetEnum | string): void;
         static drum(targetAlias?: TargetEnum | string): void;
-        static useMusicInstrument(instrument: IMyGameObject, missingMessage: string, targetAlias?: TargetEnum | string): void;
+        static useMusicInstrument(
+            instrument: IMyGameObject,
+            missingMessage: string,
+            targetAlias?: TargetEnum | string,
+        ): void;
     }
 }
 declare namespace Scripts {
@@ -472,85 +596,85 @@ declare enum DirectionEnum {
     West = 6,
     North = 0,
     East = 2,
-    South = 4
+    South = 4,
 }
 declare enum ColorEnum {
-    none = "0xffff",
-    red = "0x0021",
-    green = "0x0044",
-    orange = "0x002c",
-    pureWhite = "0x0B1D"
+    none = '0xffff',
+    red = '0x0021',
+    green = '0x0044',
+    orange = '0x002c',
+    pureWhite = '0x0B1D',
 }
 declare enum TargetEnum {
-    self = "self",
-    lastattack = "lastattack",
-    laststatus = "laststatus",
-    lasttarget = "lasttarget"
+    self = 'self',
+    lastattack = 'lastattack',
+    laststatus = 'laststatus',
+    lasttarget = 'lasttarget',
 }
 declare enum CustomStatusBarEnum {
     close = 0,
-    click = 666
+    click = 666,
 }
 declare enum OcarovaniEnum {
-    mytheril = "mytheril",
-    black = "black",
-    blood = "blood"
+    mytheril = 'mytheril',
+    black = 'black',
+    blood = 'blood',
 }
 declare enum ScrollEnum {
-    kvf = "kvf",
-    bolt = "bolt",
-    pog = "pog",
-    ijs = "ijs",
-    port = "port",
-    ef = "ef",
-    para = "para",
-    wos = "wos",
-    ivm = "ivm",
-    ress = "ress",
-    recall = "recall",
-    heal = "heal"
+    kvf = 'kvf',
+    bolt = 'bolt',
+    pog = 'pog',
+    ijs = 'ijs',
+    port = 'port',
+    ef = 'ef',
+    para = 'para',
+    wos = 'wos',
+    ivm = 'ivm',
+    ress = 'ress',
+    recall = 'recall',
+    heal = 'heal',
 }
 declare enum TargetIndicationEnum {
-    none = "none",
-    large = "large"
+    none = 'none',
+    large = 'large',
 }
 declare enum ReagentsEnum {
-    mr = "mr",
-    ss = "ss",
-    bm = "bm",
-    bp = "bp",
-    ga = "ga",
-    gi = "gi",
-    ns = "ns",
-    sa = "sa"
+    mr = 'mr',
+    ss = 'ss',
+    bm = 'bm',
+    bp = 'bp',
+    ga = 'ga',
+    gi = 'gi',
+    ns = 'ns',
+    sa = 'sa',
 }
 declare enum FlagsEnum {
-    fast = "fast",
-    near = "near",
-    mobile = "mobile",
-    item = "item",
-    human = "human",
-    nothuman = "nothuman",
-    live = "live",
-    dead = "dead",
-    injured = "injured",
-    next = "next",
-    ignorefriends = "ignorefriends",
-    ignorefriendlytypes = "ignorefriendlytypes",
-    ignoreenemies = "ignoreenemies",
-    ignoreself = "ignoreself",
-    inlos = "inlos",
-    nearmouse = "nearmouse",
-    recurse = "recurse"
+    fast = 'fast',
+    near = 'near',
+    mobile = 'mobile',
+    item = 'item',
+    human = 'human',
+    nothuman = 'nothuman',
+    live = 'live',
+    dead = 'dead',
+    injured = 'injured',
+    next = 'next',
+    ignorefriends = 'ignorefriends',
+    ignorefriendlytypes = 'ignorefriendlytypes',
+    ignoreenemies = 'ignoreenemies',
+    ignoreself = 'ignoreself',
+    inlos = 'inlos',
+    nearmouse = 'nearmouse',
+    recurse = 'recurse',
 }
 declare enum NotorietyEnum {
-    blue = "blue",
-    green = "green",
-    gray = "gray",
-    criminal = "criminal",
-    orange = "orange",
-    red = "red",
-    yellow = "yellow"
+    blue = 'blue',
+    green = 'green',
+    gray = 'gray',
+    criminal = 'criminal',
+    orange = 'orange',
+    red = 'red',
+    yellow = 'yellow',
 }
 declare enum NotorietyNum {
     blue = 1,
@@ -559,69 +683,69 @@ declare enum NotorietyNum {
     criminal = 4,
     orange = 5,
     red = 6,
-    yellow = 7
+    yellow = 7,
 }
 declare enum PotionsEnum {
-    tmr = "tmr",
-    mr = "mr",
-    gh = "gh",
-    gs = "gs",
-    ga = "ga",
-    gb = "gb",
-    tr = "tr",
-    gc = "gc",
-    lc = "lc",
-    lp = "lp",
-    dp = "dp",
-    ns = "ns",
-    shrink = "shrink",
-    lavabomb = "lavabomb",
-    invis = "invis"
+    tmr = 'tmr',
+    mr = 'mr',
+    gh = 'gh',
+    gs = 'gs',
+    ga = 'ga',
+    gb = 'gb',
+    tr = 'tr',
+    gc = 'gc',
+    lc = 'lc',
+    lp = 'lp',
+    dp = 'dp',
+    ns = 'ns',
+    shrink = 'shrink',
+    lavabomb = 'lavabomb',
+    invis = 'invis',
 }
 declare enum NecroScrollEnum {
-    vfp = "vfp",
-    kalnox = "kalnox",
-    haluze = "haluze"
+    vfp = 'vfp',
+    kalnox = 'kalnox',
+    haluze = 'haluze',
 }
 declare enum TimersEnum {
-    drink = "drink",
-    gs = "gs",
-    hiding = "hiding",
-    invis = "invis",
-    invisLong = "invisLong",
-    bandage = "bandage"
+    drink = 'drink',
+    gs = 'gs',
+    hiding = 'hiding',
+    invis = 'invis',
+    invisLong = 'invisLong',
+    bandage = 'bandage',
 }
 declare enum GlobalEnum {
-    customStatusBars = "customStatusBars"
+    customStatusBars = 'customStatusBars',
 }
 declare enum PortBookOptionsEnum {
-    opravaStats = "opravaStats",
-    mark = "mark",
-    kop = "kop",
-    nabiti = "nabiti"
+    opravaStats = 'opravaStats',
+    mark = 'mark',
+    kop = 'kop',
+    nabiti = 'nabiti',
 }
 declare enum SelectionTypeEnum {
-    gump = "gump",
-    menu = "menu"
+    gump = 'gump',
+    menu = 'menu',
 }
 declare enum MedicActionsEnum {
-    pull = "KPZ - Pull",
-    jump = "KPZ - Jump",
-    switchHp = "KPZ - Switch HP"
+    pull = 'KPZ - Pull',
+    jump = 'KPZ - Jump',
+    switchHp = 'KPZ - Switch HP',
 }
 declare enum RenameNameType {
-    autoName = "autoName",
-    nameList = "nameList"
+    autoName = 'autoName',
+    nameList = 'nameList',
 }
 declare enum TargetExEnum {
-    selfinjured = "selfinjured",
-    laststatusenemy = "laststatusenemy",
-    mount = "mount",
-    nearinjuredalie = "nearinjuredalie",
-    nearinjuredalielos = "nearinjuredalielos",
-    mostinjuredalie = "mostinjuredalie",
-    mostinjuredalielos = "mostinjuredalielos",
-    lasttargetmobile = "lasttargetmobile"
+    selfinjured = 'selfinjured',
+    laststatusenemy = 'laststatusenemy',
+    mount = 'mount',
+    nearinjuredalie = 'nearinjuredalie',
+    nearinjuredalielos = 'nearinjuredalielos',
+    mostinjuredalie = 'mostinjuredalie',
+    mostinjuredalielos = 'mostinjuredalielos',
+    lasttargetmobile = 'lasttargetmobile',
 }
 interface IMyGameObject {
     graphic: string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -170,6 +170,7 @@ declare namespace Scripts {
         static lootAllFrom(delay?: number): void;
         private static lootCorpsesAround;
         static lootCorpseId(corpseId: string, cut?: boolean, weapon?: boolean): void;
+        private static grabItems;
         private static getBagSnapshot;
         private static moveLootToLootBag;
         private static displayLoot;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -22,20 +22,8 @@ declare function cestovniKniha(selection?: PortBookOptionsEnum): void;
 declare function cleanObjectInBag(object: any, objectName?: string): void;
 declare function craftNext(): void;
 declare function craftSelect(): void;
-declare function drink(
-    potionName: PotionsEnum,
-    switchWarModeWhenNeeded?: boolean,
-    displayTimers?: boolean,
-    refillEmptyLimit?: number,
-    displayInvisLongTimer?: boolean,
-): void;
-declare function drinkFill(
-    potionName: PotionsEnum,
-    switchWarModeWhenNeeded?: boolean,
-    displayTimers?: boolean,
-    refillEmptyLimit?: number,
-    displayInvisLongTimer?: boolean,
-): void;
+declare function drink(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, displayTimers?: boolean, refillEmptyLimit?: number, displayInvisLongTimer?: boolean): void;
+declare function drinkFill(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, displayTimers?: boolean, refillEmptyLimit?: number, displayInvisLongTimer?: boolean): void;
 declare function drum(target?: TargetEnum): void;
 declare function ef(self?: boolean, scroll?: boolean, timer?: number): void;
 declare function enemy(): void;
@@ -86,18 +74,8 @@ declare function statusBar(): void;
 declare function summon(creature: string, target?: TargetEnum): void;
 declare function taming(allAround?: boolean, opts?: ITamingOptions): void;
 declare function tamingTrain(robeOfDruids?: boolean): void;
-declare function targetNext(
-    timeToStorePreviousTargets?: number,
-    additionalFlags?: FlagsEnum[],
-    notoriety?: NotorietyEnum[],
-    opts?: ITargetNextOpts,
-): void;
-declare function targetPrevious(
-    timeToStorePreviousTargets?: number,
-    additionalFlags?: string[],
-    notoriety?: string[],
-    opts?: ITargetNextOpts,
-): void;
+declare function targetNext(timeToStorePreviousTargets?: number, additionalFlags?: FlagsEnum[], notoriety?: NotorietyEnum[], opts?: ITargetNextOpts): void;
+declare function targetPrevious(timeToStorePreviousTargets?: number, additionalFlags?: string[], notoriety?: string[], opts?: ITargetNextOpts): void;
 declare function terminateAll(): void;
 declare function tracking(who?: string): void;
 declare function travelBook(selection?: PortBookOptionsEnum): void;
@@ -125,41 +103,17 @@ declare function parseParam(param: any): any;
 declare namespace Scripts {
     class Auto {
         static lagProtection(enemy: GameObject, run?: number): void;
-        static getToDistanceIfNeeded(
-            enemy: GameObject,
-            distance?: number,
-            run?: number,
-            maxWalkingTime?: number,
-        ): boolean;
-        static killObject(
-            serialToKill: string,
-            poisonTrain?: boolean,
-            waitUntilDead?: boolean,
-            kill?: boolean,
-            distance?: number,
-            lagProtection?: boolean,
-        ): void;
+        static getToDistanceIfNeeded(enemy: GameObject, distance?: number, run?: number, maxWalkingTime?: number): boolean;
+        static killObject(serialToKill: string, poisonTrain?: boolean, waitUntilDead?: boolean, kill?: boolean, distance?: number, lagProtection?: boolean): void;
     }
 }
 declare namespace Scripts {
     class Clean {
         static cleanBag(): void;
         static cleanObjectInBag(object: any, objectName?: string): void;
-        static cleanObjectInBagCoord(
-            object: any,
-            objectName?: string,
-            recuseSearch?: boolean,
-            coordinates?: ICoordinates,
-            delta?: number,
-        ): ICoordinates;
+        static cleanObjectInBagCoord(object: any, objectName?: string, recuseSearch?: boolean, coordinates?: ICoordinates, delta?: number): ICoordinates;
         static getSerialsFromMyGameObject(type: IMyGameObject, recuseSearch?: boolean): string[];
-        static cleanMyGameObjectInBag(
-            type: IMyGameObject,
-            tName?: string,
-            recuseSearch?: boolean,
-            coordinates?: ICoordinates,
-            delta?: number,
-        ): ICoordinates;
+        static cleanMyGameObjectInBag(type: IMyGameObject, tName?: string, recuseSearch?: boolean, coordinates?: ICoordinates, delta?: number): ICoordinates;
         static findUniqueGameObjects(object: any): Array<IMyGameObject>;
         static getGameObjectList(object: any): Array<IMyGameObject>;
         static sortBackpackCaleb(): void;
@@ -169,11 +123,7 @@ declare namespace Scripts {
     class Common {
         static svetlo(shouldCast?: boolean): void;
         static shrinkKad(): void;
-        static bandageSelf(
-            minimalCountToWarn?: number,
-            pathToNoBandagesWavFile?: string,
-            failedMessage?: boolean,
-        ): void;
+        static bandageSelf(minimalCountToWarn?: number, pathToNoBandagesWavFile?: string, failedMessage?: boolean): void;
         static massMove(requiredCountInTarget?: number, onlyType?: boolean): void;
         static mysticCounter(): void;
         static hideAll(): void;
@@ -210,7 +160,7 @@ declare namespace Scripts {
         static useKlamak(lvl: number, useAim?: boolean, priorityList?: string[], ignoreSerials?: string[]): void;
     }
 }
-declare const LOOT_BAG = 'loot/bag';
+declare const LOOT_BAG = "loot/bag";
 declare namespace Scripts {
     class Loot {
         static addLootBag(): number;
@@ -266,7 +216,10 @@ declare namespace Scripts {
         static ignoreMyPets(): void;
         static getAvailableNames(): string[];
         static getRandomAvailableName(): string;
-        static savePet(pet: { serial: string; name: string }): void;
+        static savePet(pet: {
+            serial: string;
+            name: string;
+        }): void;
         static getNewPet(): IMyPet | undefined;
         static killTarget(): void;
         static killAll(): void;
@@ -289,22 +242,10 @@ declare namespace Scripts {
         static getEmptyBottle(): string;
         static getKadForPotion(potion: IPotion): string;
         static getMortar(): string;
-        static drinkPotion(
-            potionName: PotionsEnum,
-            switchWarModeWhenNeeded?: boolean,
-            displayTimers?: boolean,
-            displayInfo?: boolean,
-            refillEmptyLimit?: number,
-            displayInvisLongTimer?: boolean,
-        ): void;
+        static drinkPotion(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, displayTimers?: boolean, displayInfo?: boolean, refillEmptyLimit?: number, displayInvisLongTimer?: boolean): void;
         static gmMortar(potionName: PotionsEnum): void;
         static alchemy(potionName: PotionsEnum): void;
-        static fillPotion(
-            potionName: PotionsEnum,
-            switchWarModeWhenNeeded?: boolean,
-            kadSerial?: string,
-            emptyBottleSerial?: string,
-        ): void;
+        static fillPotion(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, kadSerial?: string, emptyBottleSerial?: string): void;
         static potionToKad(potionName: PotionsEnum, switchWarModeWhenNeeded?: boolean, kadSerial?: string): void;
     }
 }
@@ -337,28 +278,11 @@ declare namespace Scripts {
         static addEnemy(): string;
         static resetFriends(): void;
         static resetEnemies(): void;
-        static targetNext(
-            reverse: boolean,
-            timeToStorePreviousTargets: number,
-            additionalFlags: string[],
-            notoriety: string[],
-            opts: ITargetNextOpts,
-        ): void;
+        static targetNext(reverse: boolean, timeToStorePreviousTargets: number, additionalFlags: string[], notoriety: string[], opts: ITargetNextOpts): void;
         static manualTarget(opts: ITargetNextOpts): void;
-        static highlightEnemy(
-            enemySerial: string,
-            enemy: GameObject,
-            showStatusBar: boolean,
-            targetIndicationEnum: TargetIndicationEnum,
-            statusBarPosition: ICoordinates,
-        ): void;
+        static highlightEnemy(enemySerial: string, enemy: GameObject, showStatusBar: boolean, targetIndicationEnum: TargetIndicationEnum, statusBarPosition: ICoordinates): void;
         static isFriendlyTargetType(graphic: string, color: string, name: string): boolean;
-        static targetNextMonster(
-            reverse: boolean,
-            timeToStorePreviousTargets: number,
-            notoriety: string[],
-            statusWrapperOpt: any,
-        ): TargetResult;
+        static targetNextMonster(reverse: boolean, timeToStorePreviousTargets: number, notoriety: string[], statusWrapperOpt: any): TargetResult;
         static showStatusBarOnWrapper(serial: string, statusWrapperOpt: any): void;
     }
 }
@@ -389,46 +313,20 @@ declare namespace Scripts {
 }
 declare namespace Scripts {
     class Utils {
-        static selectMenu(
-            menuName: string | ISpecialSelection,
-            selections: Array<string | ISpecialSelection>,
-            firstCall?: boolean,
-        ): void;
+        static selectMenu(menuName: string | ISpecialSelection, selections: Array<string | ISpecialSelection>, firstCall?: boolean): void;
         static useAndSelect(serial: string, selections: ISelect[], use?: boolean): void;
-        static refill(
-            obj: IMyGameObject,
-            sourceContainerId: string,
-            quantity?: number,
-            targetContainerId?: string,
-            refillJustWhenIHaveNothing?: boolean,
-            itemName?: string,
-            sourceContainerIsItemOnGround?: boolean,
-        ): number;
+        static refill(obj: IMyGameObject, sourceContainerId: string, quantity?: number, targetContainerId?: string, refillJustWhenIHaveNothing?: boolean, itemName?: string, sourceContainerIsItemOnGround?: boolean): number;
         static getObjSerials(obj: IMyGameObject, container?: string): string[];
         static getColorByNotoriety(notoriety?: number): number;
-        static countObjectInContainer(
-            obj: IMyGameObject,
-            container?: string,
-            containerIsObjItemOnGround?: boolean,
-        ): number;
+        static countObjectInContainer(obj: IMyGameObject, container?: string, containerIsObjItemOnGround?: boolean): number;
         static countItemsBySerials(itemsSerials: string[]): number;
         static moveObjectToContainer(obj: any, fromContainer: string, targetContainer: string): void;
         static moveItems(itemsSerials: string[], targetContainerId: string, quantity: number): number;
-        static waitWhileSomethingInJournal(
-            messages: string[],
-            wait?: number,
-            timeAhead?: number,
-            flags?: string,
-        ): number;
+        static waitWhileSomethingInJournal(messages: string[], wait?: number, timeAhead?: number, flags?: string): number;
         static worldSaveCheckWait(): void;
         static log(message: string, color?: ColorEnum): void;
         static playerPrint(message: string, color?: ColorEnum | number | string, fastPrint?: boolean): void;
-        static charPrint(
-            serial: string,
-            message: string,
-            color?: ColorEnum | number | string,
-            fastPrint?: boolean,
-        ): void;
+        static charPrint(serial: string, message: string, color?: ColorEnum | number | string, fastPrint?: boolean): void;
         static waitTarget(target?: TargetEnum | string): void;
         static resetTimer(timer: string): void;
         static waitWhileTargeting(): void;
@@ -443,22 +341,15 @@ declare namespace Scripts {
         static printColoredHpBar(target: string, percent: number): void;
         static getLivingObjectInDistance(objectSerial: string): GameObject | null;
         static printDamage(serial: string, previousHp: number, force?: boolean): void;
-        static use(
-            val: IMyGameObject | IMyGameObject[],
-            name?: string,
-            minimalCountForWarn?: number,
-            warnWavPath?: string,
-        ): void;
+        static use(val: IMyGameObject | IMyGameObject[], name?: string, minimalCountForWarn?: number, warnWavPath?: string): void;
         static setTargetAlias(targetAliasToSet: string, message?: string): void;
         static findFirstType(myGameObject: IMyGameObject, layer?: number): string | undefined;
         static walkToSerial(serial: string, distance?: number): void;
         static targetObjectNotSelf(objectAlias: string, message?: string): void;
-        static createGameObjectSelections(
-            selections: Array<{
-                ask: string;
-                addObject: string;
-            }>,
-        ): void;
+        static createGameObjectSelections(selections: Array<{
+            ask: string;
+            addObject: string;
+        }>): void;
         static openContainer(s: string, maxWaitingTime?: number): void;
         static isItemStackable(serial: string): boolean;
         static askForCount(): number;
@@ -495,12 +386,7 @@ declare namespace Scripts {
         static makeProgress(): boolean;
         static refOrMake(count: number, resourcePath: string): void;
         static make(count: number, objectAsString: string, setInputs?: boolean): void;
-        static countMaterialForOneItem(
-            objectAsString: string,
-            callStack?: number,
-            count?: number,
-            crafting?: boolean,
-        ): void;
+        static countMaterialForOneItem(objectAsString: string, callStack?: number, count?: number, crafting?: boolean): void;
         static makeFromSelection(): void;
         static listMakeMenu(): void;
         static confirmMakeMenu(): void;
@@ -566,11 +452,7 @@ declare namespace Scripts {
         static harp(targetAlias?: TargetEnum | string): void;
         static lute(targetAlias?: TargetEnum | string): void;
         static drum(targetAlias?: TargetEnum | string): void;
-        static useMusicInstrument(
-            instrument: IMyGameObject,
-            missingMessage: string,
-            targetAlias?: TargetEnum | string,
-        ): void;
+        static useMusicInstrument(instrument: IMyGameObject, missingMessage: string, targetAlias?: TargetEnum | string): void;
     }
 }
 declare namespace Scripts {
@@ -596,85 +478,85 @@ declare enum DirectionEnum {
     West = 6,
     North = 0,
     East = 2,
-    South = 4,
+    South = 4
 }
 declare enum ColorEnum {
-    none = '0xffff',
-    red = '0x0021',
-    green = '0x0044',
-    orange = '0x002c',
-    pureWhite = '0x0B1D',
+    none = "0xffff",
+    red = "0x0021",
+    green = "0x0044",
+    orange = "0x002c",
+    pureWhite = "0x0B1D"
 }
 declare enum TargetEnum {
-    self = 'self',
-    lastattack = 'lastattack',
-    laststatus = 'laststatus',
-    lasttarget = 'lasttarget',
+    self = "self",
+    lastattack = "lastattack",
+    laststatus = "laststatus",
+    lasttarget = "lasttarget"
 }
 declare enum CustomStatusBarEnum {
     close = 0,
-    click = 666,
+    click = 666
 }
 declare enum OcarovaniEnum {
-    mytheril = 'mytheril',
-    black = 'black',
-    blood = 'blood',
+    mytheril = "mytheril",
+    black = "black",
+    blood = "blood"
 }
 declare enum ScrollEnum {
-    kvf = 'kvf',
-    bolt = 'bolt',
-    pog = 'pog',
-    ijs = 'ijs',
-    port = 'port',
-    ef = 'ef',
-    para = 'para',
-    wos = 'wos',
-    ivm = 'ivm',
-    ress = 'ress',
-    recall = 'recall',
-    heal = 'heal',
+    kvf = "kvf",
+    bolt = "bolt",
+    pog = "pog",
+    ijs = "ijs",
+    port = "port",
+    ef = "ef",
+    para = "para",
+    wos = "wos",
+    ivm = "ivm",
+    ress = "ress",
+    recall = "recall",
+    heal = "heal"
 }
 declare enum TargetIndicationEnum {
-    none = 'none',
-    large = 'large',
+    none = "none",
+    large = "large"
 }
 declare enum ReagentsEnum {
-    mr = 'mr',
-    ss = 'ss',
-    bm = 'bm',
-    bp = 'bp',
-    ga = 'ga',
-    gi = 'gi',
-    ns = 'ns',
-    sa = 'sa',
+    mr = "mr",
+    ss = "ss",
+    bm = "bm",
+    bp = "bp",
+    ga = "ga",
+    gi = "gi",
+    ns = "ns",
+    sa = "sa"
 }
 declare enum FlagsEnum {
-    fast = 'fast',
-    near = 'near',
-    mobile = 'mobile',
-    item = 'item',
-    human = 'human',
-    nothuman = 'nothuman',
-    live = 'live',
-    dead = 'dead',
-    injured = 'injured',
-    next = 'next',
-    ignorefriends = 'ignorefriends',
-    ignorefriendlytypes = 'ignorefriendlytypes',
-    ignoreenemies = 'ignoreenemies',
-    ignoreself = 'ignoreself',
-    inlos = 'inlos',
-    nearmouse = 'nearmouse',
-    recurse = 'recurse',
+    fast = "fast",
+    near = "near",
+    mobile = "mobile",
+    item = "item",
+    human = "human",
+    nothuman = "nothuman",
+    live = "live",
+    dead = "dead",
+    injured = "injured",
+    next = "next",
+    ignorefriends = "ignorefriends",
+    ignorefriendlytypes = "ignorefriendlytypes",
+    ignoreenemies = "ignoreenemies",
+    ignoreself = "ignoreself",
+    inlos = "inlos",
+    nearmouse = "nearmouse",
+    recurse = "recurse"
 }
 declare enum NotorietyEnum {
-    blue = 'blue',
-    green = 'green',
-    gray = 'gray',
-    criminal = 'criminal',
-    orange = 'orange',
-    red = 'red',
-    yellow = 'yellow',
+    blue = "blue",
+    green = "green",
+    gray = "gray",
+    criminal = "criminal",
+    orange = "orange",
+    red = "red",
+    yellow = "yellow"
 }
 declare enum NotorietyNum {
     blue = 1,
@@ -683,69 +565,69 @@ declare enum NotorietyNum {
     criminal = 4,
     orange = 5,
     red = 6,
-    yellow = 7,
+    yellow = 7
 }
 declare enum PotionsEnum {
-    tmr = 'tmr',
-    mr = 'mr',
-    gh = 'gh',
-    gs = 'gs',
-    ga = 'ga',
-    gb = 'gb',
-    tr = 'tr',
-    gc = 'gc',
-    lc = 'lc',
-    lp = 'lp',
-    dp = 'dp',
-    ns = 'ns',
-    shrink = 'shrink',
-    lavabomb = 'lavabomb',
-    invis = 'invis',
+    tmr = "tmr",
+    mr = "mr",
+    gh = "gh",
+    gs = "gs",
+    ga = "ga",
+    gb = "gb",
+    tr = "tr",
+    gc = "gc",
+    lc = "lc",
+    lp = "lp",
+    dp = "dp",
+    ns = "ns",
+    shrink = "shrink",
+    lavabomb = "lavabomb",
+    invis = "invis"
 }
 declare enum NecroScrollEnum {
-    vfp = 'vfp',
-    kalnox = 'kalnox',
-    haluze = 'haluze',
+    vfp = "vfp",
+    kalnox = "kalnox",
+    haluze = "haluze"
 }
 declare enum TimersEnum {
-    drink = 'drink',
-    gs = 'gs',
-    hiding = 'hiding',
-    invis = 'invis',
-    invisLong = 'invisLong',
-    bandage = 'bandage',
+    drink = "drink",
+    gs = "gs",
+    hiding = "hiding",
+    invis = "invis",
+    invisLong = "invisLong",
+    bandage = "bandage"
 }
 declare enum GlobalEnum {
-    customStatusBars = 'customStatusBars',
+    customStatusBars = "customStatusBars"
 }
 declare enum PortBookOptionsEnum {
-    opravaStats = 'opravaStats',
-    mark = 'mark',
-    kop = 'kop',
-    nabiti = 'nabiti',
+    opravaStats = "opravaStats",
+    mark = "mark",
+    kop = "kop",
+    nabiti = "nabiti"
 }
 declare enum SelectionTypeEnum {
-    gump = 'gump',
-    menu = 'menu',
+    gump = "gump",
+    menu = "menu"
 }
 declare enum MedicActionsEnum {
-    pull = 'KPZ - Pull',
-    jump = 'KPZ - Jump',
-    switchHp = 'KPZ - Switch HP',
+    pull = "KPZ - Pull",
+    jump = "KPZ - Jump",
+    switchHp = "KPZ - Switch HP"
 }
 declare enum RenameNameType {
-    autoName = 'autoName',
-    nameList = 'nameList',
+    autoName = "autoName",
+    nameList = "nameList"
 }
 declare enum TargetExEnum {
-    selfinjured = 'selfinjured',
-    laststatusenemy = 'laststatusenemy',
-    mount = 'mount',
-    nearinjuredalie = 'nearinjuredalie',
-    nearinjuredalielos = 'nearinjuredalielos',
-    mostinjuredalie = 'mostinjuredalie',
-    mostinjuredalielos = 'mostinjuredalielos',
-    lasttargetmobile = 'lasttargetmobile',
+    selfinjured = "selfinjured",
+    laststatusenemy = "laststatusenemy",
+    mount = "mount",
+    nearinjuredalie = "nearinjuredalie",
+    nearinjuredalielos = "nearinjuredalielos",
+    mostinjuredalie = "mostinjuredalie",
+    mostinjuredalielos = "mostinjuredalielos",
+    lasttargetmobile = "lasttargetmobile"
 }
 interface IMyGameObject {
     graphic: string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -169,7 +169,7 @@ declare namespace Scripts {
         static corpses(cut?: boolean): void;
         static lootAllFrom(delay?: number): void;
         private static lootCorpsesAround;
-        static lootCorpseId(corpseId: string, cut?: boolean, weapon?: boolean): void;
+        static lootCorpseId(corpseId: string, cut?: boolean): void;
         private static grabItems;
         private static getBagSnapshot;
         private static moveLootToLootBag;

--- a/dist/index.js
+++ b/dist/index.js
@@ -2416,7 +2416,7 @@ var __assign = (this && this.__assign) || function () {
 function version() {
     Orion.Print(-1, '+-------------');
     Orion.Print(-1, 'msviha/orionuo');
-    Orion.Print(-1, 'version 1.1.2');
+    Orion.Print(-1, 'version 1.2.0');
     Orion.Print(-1, '-------------+');
 }
 function Autostart() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3699,7 +3699,7 @@ var Scripts;
             for (var _a = 0, itemsOnGround_1 = itemsOnGround; _a < itemsOnGround_1.length; _a++) {
                 var itemId = itemsOnGround_1[_a];
                 Orion.MoveItem(itemId, 0, 'myLootBag');
-                Orion.Wait(serverLagActionsLeft ? 50 : 350);
+                Orion.Wait(serverLagActionsLeft > 0 ? 50 : 350);
                 serverLagActionsLeft--;
             }
         };
@@ -3722,7 +3722,7 @@ var Scripts;
                 for (var _i = 0, itemsInCorpse_2 = itemsInCorpse; _i < itemsInCorpse_2.length; _i++) {
                     var itemId = itemsInCorpse_2[_i];
                     Orion.MoveItem(itemId, 0, 'myLootBag');
-                    Orion.Wait(serverLagActionsLeft ? 150 : 500);
+                    Orion.Wait(serverLagActionsLeft > 0 ? 150 : 500);
                     serverLagActionsLeft--;
                 }
             }
@@ -3731,6 +3731,9 @@ var Scripts;
             return Orion.FindType(-1, -1, 'backpack', 'item', undefined, undefined, false);
         };
         Loot.moveLootToLootBag = function (oldSnapshot) {
+            if (!Orion.FindObject(LOOT_BAG)) {
+                return;
+            }
             this.getBagSnapshot()
                 .filter(function (serial) { return oldSnapshot.indexOf(serial) < 0; })
                 .forEach(function (serial, i) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3683,37 +3683,31 @@ var Scripts;
                 }
             }
         };
-        Loot.lootCorpsesAround = function (cut, weapon) {
+        Loot.lootCorpsesAround = function (cut) {
             var listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
             var LHand = Orion.ObjAtLayer(1);
             var RHand = Orion.ObjAtLayer(2);
             while (listOfCorpses.length) {
                 for (var _i = 0, listOfCorpses_1 = listOfCorpses; _i < listOfCorpses_1.length; _i++) {
                     var id = listOfCorpses_1[_i];
-                    Scripts.Loot.lootCorpseId(id, cut, weapon);
+                    Scripts.Loot.lootCorpseId(id, cut);
                     Orion.Ignore(id);
                     Orion.Wait(100);
                 }
                 listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
             }
-            if (weapon) {
-                Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
-            }
+            Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
             var itemsOnGround = Orion.FindList('lootItems', 'ground', 'fast', 4);
             this.grabItems(itemsOnGround);
         };
-        Loot.lootCorpseId = function (corpseId, cut, weapon) {
+        Loot.lootCorpseId = function (corpseId, cut) {
             Orion.OpenContainer(corpseId, 5000, "Container id " + corpseId + " not found");
             var hasLootBag = Orion.Count('0x0E76', '0x049A', corpseId) > 0;
             if (hasLootBag && cut) {
                 if (Orion.FindObject('cutWeapon')) {
+                    Orion.CancelWaitTarget();
+                    Orion.WaitTargetObject(corpseId);
                     Orion.UseObject('cutWeapon');
-                    Orion.WaitForTarget(1000);
-                    Orion.TargetObject(corpseId);
-                }
-                else if (weapon) {
-                    Orion.UseObject('fightWeapon');
-                    Orion.WaitForTarget(1000) && Orion.CancelTarget();
                 }
                 Orion.Wait(250);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3663,7 +3663,7 @@ var Scripts;
         };
         Loot.corpses = function (cut) {
             if (cut === void 0) { cut = true; }
-            Orion.ClearJournal();
+            Orion.ClearJournal('You put the');
             var snapshot = this.getBagSnapshot();
             this.lootCorpsesAround(cut);
             Orion.Wait(350);
@@ -3705,8 +3705,11 @@ var Scripts;
                 Orion.WaitForTarget(1000);
                 Orion.TargetObject(corpseId);
                 if (weapon) {
+                    var LHand = Orion.ObjAtLayer(1);
+                    var RHand = Orion.ObjAtLayer(2);
                     Orion.UseObject('fightWeapon');
                     Orion.WaitForTarget(1000) && Orion.CancelTarget();
+                    Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
                 }
                 Orion.Wait(250);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3695,16 +3695,9 @@ var Scripts;
                 listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
             }
             var itemsOnGround = Orion.FindList('lootItems', 'ground', 'fast', 4);
-            var serverLagActionsLeft = 4;
-            for (var _a = 0, itemsOnGround_1 = itemsOnGround; _a < itemsOnGround_1.length; _a++) {
-                var itemId = itemsOnGround_1[_a];
-                Orion.MoveItem(itemId, 0, 'myLootBag');
-                Orion.Wait(serverLagActionsLeft > 0 ? 50 : 350);
-                serverLagActionsLeft--;
-            }
+            this.grabItems(itemsOnGround);
         };
         Loot.lootCorpseId = function (corpseId, cut, weapon) {
-            var serverLagActionsLeft = 4;
             Orion.OpenContainer(corpseId, 5000, "Container id " + corpseId + " not found");
             var hasLootBag = Orion.Count('0x0E76', '0x049A', corpseId) > 0;
             if (hasLootBag && cut) {
@@ -3719,12 +3712,16 @@ var Scripts;
             }
             var itemsInCorpse = Orion.FindList('lootItems', corpseId);
             if (itemsInCorpse.length) {
-                for (var _i = 0, itemsInCorpse_2 = itemsInCorpse; _i < itemsInCorpse_2.length; _i++) {
-                    var itemId = itemsInCorpse_2[_i];
-                    Orion.MoveItem(itemId, 0, 'myLootBag');
-                    Orion.Wait(serverLagActionsLeft > 0 ? 150 : 500);
-                    serverLagActionsLeft--;
-                }
+                this.grabItems(itemsInCorpse);
+            }
+        };
+        Loot.grabItems = function (serials) {
+            var serverLagActionsLeft = 4;
+            for (var _i = 0, serials_2 = serials; _i < serials_2.length; _i++) {
+                var serial = serials_2[_i];
+                Orion.MoveItem(serial, 0, 'myLootBag');
+                Orion.Wait(serverLagActionsLeft > 0 ? 150 : 500);
+                serverLagActionsLeft--;
             }
         };
         Loot.getBagSnapshot = function () {
@@ -6356,8 +6353,8 @@ var Scripts;
                 return;
             }
             serials = Orion.FindType(graphic);
-            for (var _i = 0, serials_2 = serials; _i < serials_2.length; _i++) {
-                var s = serials_2[_i];
+            for (var _i = 0, serials_3 = serials; _i < serials_3.length; _i++) {
+                var s = serials_3[_i];
                 Orion.Click(s);
                 Orion.Wait(100);
                 if (Orion.FindObject(s).Name().indexOf(name) === 0) {
@@ -7445,8 +7442,8 @@ var Scripts;
                     if (!serials.length) {
                         continue;
                     }
-                    for (var _b = 0, serials_3 = serials; _b < serials_3.length; _b++) {
-                        var serial = serials_3[_b];
+                    for (var _b = 0, serials_4 = serials; _b < serials_4.length; _b++) {
+                        var serial = serials_4[_b];
                         var oreObject = Orion.FindObject(serial);
                         if (ore.color === oreObject.Color()) {
                             Orion.Drop(serial);

--- a/dist/index.js
+++ b/dist/index.js
@@ -3646,9 +3646,7 @@ var Scripts;
             if (!cutWeapon) {
                 var nbDaggerSerial = Scripts.Utils.findFirstType(gameObject.uncategorized.nbDagger, 1);
                 if (!nbDaggerSerial) {
-                    Scripts.Utils.createGameObjectSelections([
-                        { ask: 'Cim budes rezat ?', addObject: CUT_WEAPON }
-                    ]);
+                    Scripts.Utils.createGameObjectSelections([{ ask: 'Cim budes rezat ?', addObject: CUT_WEAPON }]);
                     cutWeapon = Orion.FindObject(CUT_WEAPON);
                 }
                 else {
@@ -3680,7 +3678,7 @@ var Scripts;
             if (itemsInCorpse.length) {
                 for (var _i = 0, itemsInCorpse_1 = itemsInCorpse; _i < itemsInCorpse_1.length; _i++) {
                     var itemId = itemsInCorpse_1[_i];
-                    Orion.MoveItem(itemId, 0, "myLootBag");
+                    Orion.MoveItem(itemId, 0, 'myLootBag');
                     Orion.Wait(delay);
                 }
             }
@@ -3708,7 +3706,7 @@ var Scripts;
         Loot.lootCorpseId = function (corpseId, cut, weapon) {
             var serverLagActionsLeft = 4;
             Orion.OpenContainer(corpseId, 5000, "Container id " + corpseId + " not found");
-            var hasLootBag = Orion.Count("0x0E76", "0x049A", corpseId) > 0;
+            var hasLootBag = Orion.Count('0x0E76', '0x049A', corpseId) > 0;
             if (hasLootBag && cut) {
                 Orion.UseObject('cutWeapon');
                 Orion.WaitForTarget(1000);
@@ -3723,7 +3721,7 @@ var Scripts;
             if (itemsInCorpse.length) {
                 for (var _i = 0, itemsInCorpse_2 = itemsInCorpse; _i < itemsInCorpse_2.length; _i++) {
                     var itemId = itemsInCorpse_2[_i];
-                    Orion.MoveItem(itemId, 0, "myLootBag");
+                    Orion.MoveItem(itemId, 0, 'myLootBag');
                     Orion.Wait(serverLagActionsLeft ? 150 : 500);
                     serverLagActionsLeft--;
                 }
@@ -5457,7 +5455,7 @@ var Scripts;
             var over = hp > max;
             var currentColor = poisoned ? '#00FF00' : Scripts.Utils.determineHpColorRGB((current * 100) / lineLength);
             gump.AddText(10, 25, '0', hp + "/" + max, 0, 201);
-            gump.AddColoredPolygone(89, 35, 72, 10, "black");
+            gump.AddColoredPolygone(89, 35, 72, 10, 'black');
             gump.AddColoredPolygone(90, 35, over ? lineLength : current, 10, currentColor);
         };
         return Statusbar;
@@ -6128,7 +6126,7 @@ var Scripts;
         Utils.playerPrint = function (message, color, fastPrint) {
             if (color === void 0) { color = ColorEnum.none; }
             if (fastPrint === void 0) { fastPrint = false; }
-            Utils.charPrint(Player.Serial(), message, color);
+            Utils.charPrint(Player.Serial(), message, color, fastPrint);
         };
         Utils.charPrint = function (serial, message, color, fastPrint) {
             if (color === void 0) { color = ColorEnum.none; }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3685,6 +3685,8 @@ var Scripts;
         };
         Loot.lootCorpsesAround = function (cut, weapon) {
             var listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
+            var LHand = Orion.ObjAtLayer(1);
+            var RHand = Orion.ObjAtLayer(2);
             while (listOfCorpses.length) {
                 for (var _i = 0, listOfCorpses_1 = listOfCorpses; _i < listOfCorpses_1.length; _i++) {
                     var id = listOfCorpses_1[_i];
@@ -3694,6 +3696,9 @@ var Scripts;
                 }
                 listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
             }
+            if (weapon) {
+                Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
+            }
             var itemsOnGround = Orion.FindList('lootItems', 'ground', 'fast', 4);
             this.grabItems(itemsOnGround);
         };
@@ -3701,15 +3706,14 @@ var Scripts;
             Orion.OpenContainer(corpseId, 5000, "Container id " + corpseId + " not found");
             var hasLootBag = Orion.Count('0x0E76', '0x049A', corpseId) > 0;
             if (hasLootBag && cut) {
-                Orion.UseObject('cutWeapon');
-                Orion.WaitForTarget(1000);
-                Orion.TargetObject(corpseId);
-                if (weapon) {
-                    var LHand = Orion.ObjAtLayer(1);
-                    var RHand = Orion.ObjAtLayer(2);
+                if (Orion.FindObject('cutWeapon')) {
+                    Orion.UseObject('cutWeapon');
+                    Orion.WaitForTarget(1000);
+                    Orion.TargetObject(corpseId);
+                }
+                else if (weapon) {
                     Orion.UseObject('fightWeapon');
                     Orion.WaitForTarget(1000) && Orion.CancelTarget();
-                    Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
                 }
                 Orion.Wait(250);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orionuo",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Scripts for OrionUO assistant on Darkparadise.cz",
   "scripts": {
     "lint": "eslint './**/*.ts' --quiet --fix",

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -500,8 +500,7 @@ function lockpicking() {
  * @example external code `loot(false);`
  */
 function loot(cut = true) {
-    cut = parseParam(cut);
-    Scripts.Loot.lootCorpsesAround(cut);
+    Scripts.Loot.corpses(parseParam(cut));
 }
 
 /**

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -1,7 +1,7 @@
 function version() {
     Orion.Print(-1, '+-------------');
     Orion.Print(-1, 'msviha/orionuo');
-    Orion.Print(-1, 'version 1.1.2');
+    Orion.Print(-1, 'version 1.2.0');
     Orion.Print(-1, '-------------+');
 }
 

--- a/src/scripts/loot.ts
+++ b/src/scripts/loot.ts
@@ -69,7 +69,7 @@ namespace Scripts {
          * @param cut boolean - rezanie mrtvol? (default = true)
          */
         static corpses(cut = true) {
-            Orion.ClearJournal();
+            Orion.ClearJournal('You put the');
             const snapshot = this.getBagSnapshot();
             this.lootCorpsesAround(cut);
             Orion.Wait(350);
@@ -131,7 +131,7 @@ namespace Scripts {
                 if (weapon) {
                     const LHand = Orion.ObjAtLayer(1);
                     const RHand = Orion.ObjAtLayer(2);
-                    
+
                     Orion.UseObject('fightWeapon');
                     Orion.WaitForTarget(1000) && Orion.CancelTarget();
 

--- a/src/scripts/loot.ts
+++ b/src/scripts/loot.ts
@@ -129,8 +129,13 @@ namespace Scripts {
                 Orion.WaitForTarget(1000);
                 Orion.TargetObject(corpseId);
                 if (weapon) {
+                    const LHand = Orion.ObjAtLayer(1);
+                    const RHand = Orion.ObjAtLayer(2);
+                    
                     Orion.UseObject('fightWeapon');
                     Orion.WaitForTarget(1000) && Orion.CancelTarget();
+
+                    Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
                 }
                 Orion.Wait(250);
             }

--- a/src/scripts/loot.ts
+++ b/src/scripts/loot.ts
@@ -167,6 +167,10 @@ namespace Scripts {
          * @param oldSnapshot - array serialov na ignorovanie
          */
         private static moveLootToLootBag(oldSnapshot: string[]) {
+            if (!Orion.FindObject(LOOT_BAG)) {
+                return;
+            }
+            
             this.getBagSnapshot()
                 .filter((serial) => oldSnapshot.indexOf(serial) < 0)
                 .forEach((serial, i) => {

--- a/src/scripts/loot.ts
+++ b/src/scripts/loot.ts
@@ -113,7 +113,7 @@ namespace Scripts {
             let serverLagActionsLeft = 4;
             for (const itemId of itemsOnGround) {
                 Orion.MoveItem(itemId, 0, 'myLootBag');
-                Orion.Wait(serverLagActionsLeft ? 50 : 350);
+                Orion.Wait(serverLagActionsLeft > 0 ? 50 : 350);
                 serverLagActionsLeft--;
             }
         }
@@ -146,7 +146,7 @@ namespace Scripts {
                 for (const itemId of itemsInCorpse) {
                     // TODO doresit prehazeni veci z hlavniho baglu do myLootBag pri lotovani pytliku
                     Orion.MoveItem(itemId, 0, 'myLootBag');
-                    Orion.Wait(serverLagActionsLeft ? 150 : 500);
+                    Orion.Wait(serverLagActionsLeft > 0 ? 150 : 500);
                     serverLagActionsLeft--;
                 }
             }
@@ -170,7 +170,7 @@ namespace Scripts {
             if (!Orion.FindObject(LOOT_BAG)) {
                 return;
             }
-            
+
             this.getBagSnapshot()
                 .filter((serial) => oldSnapshot.indexOf(serial) < 0)
                 .forEach((serial, i) => {

--- a/src/scripts/loot.ts
+++ b/src/scripts/loot.ts
@@ -1,71 +1,44 @@
+const LOOT_BAG = 'loot/bag';
+
 namespace Scripts {
     export class Loot {
+        /**
+         * Nastavenie loot pytliku
+         *
+         * Return values:
+         * 0 - cancel / timeout
+         * 1 - selection of a game object
+         * 2 - selection of a static object
+         * 3 - land selection.
+         *
+         * @returns number
+         */
+        static addLootBag(): number {
+            Scripts.Utils.playerPrint('Target your loot bag');
+            return Orion.WaitForAddObject(LOOT_BAG, 60000);
+        }
+
+        /**
+         * Nastavenie nastroja na rezanie mrtvol
+         *
+         * Return values:
+         * 0 - cancel / timeout
+         * 1 - selection of a game object
+         * 2 - selection of a static object
+         * 3 - land selection.
+         *
+         * @returns number
+         */
         static addCutWeapon(): number {
             Scripts.Utils.playerPrint('Target your cut weapon');
             return Orion.WaitForAddObject('cutWeapon', 60000);
         }
 
         /**
-         * Scripts.Loot.lootCorpseId
-         * stability beta
+         * Rezanie tela
          *
-         * vylotuje mrtvolky v okoli
+         * @param carveNearestBodyAutomatically bolean
          */
-        static lootCorpsesAround(cut?: boolean, weapon?: boolean) {
-            let listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
-            while (listOfCorpses.length) {
-                for (const id of listOfCorpses) {
-                    if (cut && !Orion.FindObject(id).IsHuman()) {
-                        Orion.UseObject('cutWeapon');
-                        Orion.WaitForTarget(1000);
-                        Orion.TargetObject(id);
-                        if (weapon) {
-                            Orion.UseObject('fightWeapon');
-                            Orion.WaitForTarget(1000) && Orion.CancelTarget();
-                        }
-                    }
-
-                    Scripts.Loot.lootCorpseId(id);
-                    Orion.Ignore(id);
-                    Orion.Wait(100);
-                }
-                listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
-            }
-        }
-
-        /**
-         * Scripts.Loot.lootCorpseId
-         * stability beta
-         *
-         * vylotuje z konkretni mrtvolky veci nastavene v lootItems listu
-         */
-        static lootCorpseId(id: string) {
-            let serverLagActionsLeft = 4;
-            Orion.OpenContainer(id, 5000, `Container id ${id} not found`);
-            const itemsInCorpse = Orion.FindList('lootItems', id);
-            if (itemsInCorpse.length) {
-                for (const itemId of itemsInCorpse) {
-                    // TODO doresit prehazeni veci z hlavniho baglu do myLootBag pri lotovani pytliku
-                    Orion.MoveItem(itemId, 0, 'myLootBag');
-                    Orion.Wait(serverLagActionsLeft ? 50 : 350);
-                    serverLagActionsLeft--;
-                }
-            }
-        }
-
-        static lootAllFrom(delay = responseDelay) {
-            Scripts.Utils.targetObjectNotSelf('lootAllContainer', `Target object to loot`);
-
-            Orion.OpenContainer('lootAllContainer', 5000, `Container not found`);
-            const itemsInCorpse = Orion.FindType('any', 'any', 'lootAllContainer');
-            if (itemsInCorpse.length) {
-                for (const itemId of itemsInCorpse) {
-                    Orion.MoveItem(itemId, 0, 'myLootBag');
-                    Orion.Wait(delay);
-                }
-            }
-        }
-
         static carveBody(carveNearestBodyAutomatically = false) {
             const CUT_WEAPON = 'cutWeapon';
             let cutWeapon = Orion.FindObject(CUT_WEAPON);
@@ -88,6 +61,213 @@ namespace Scripts {
             }
 
             Orion.UseObject(cutWeapon.Serial());
+        }
+
+        /**
+         * Loot mrtvol v okoli
+         *
+         * @param cut boolean - rezanie mrtvol? (default = true)
+         */
+        static corpses(cut = true) {
+            Orion.ClearJournal();
+            const snapshot = this.getBagSnapshot();
+            this.lootCorpsesAround(cut);
+            Orion.Wait(350);
+            this.displayLoot();
+            this.moveLootToLootBag(snapshot);
+        }
+
+        /**
+         * Lootovanie vsetkeho z vybraneho kontajnera
+         *
+         * @param delay number - delay v milisekundach
+         */
+        static lootAllFrom(delay = responseDelay) {
+            Scripts.Utils.targetObjectNotSelf('lootAllContainer', `Target object to loot`);
+
+            Orion.OpenContainer('lootAllContainer', 5000, `Container not found`);
+            const itemsInCorpse = Orion.FindType('any', 'any', 'lootAllContainer');
+            if (itemsInCorpse.length) {
+                for (const itemId of itemsInCorpse) {
+                    Orion.MoveItem(itemId, 0, 'myLootBag');
+                    Orion.Wait(delay);
+                }
+            }
+        }
+
+        /**
+         * Loot mrtvol okolo v radiuse 2 policka
+         */
+        private static lootCorpsesAround(cut?: boolean, weapon?: boolean) {
+            let listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
+            while (listOfCorpses.length) {
+                for (const id of listOfCorpses) {
+                    Scripts.Loot.lootCorpseId(id, cut, weapon);
+                    Orion.Ignore(id);
+                    Orion.Wait(100);
+                }
+                listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
+            }
+
+            const itemsOnGround = Orion.FindList('lootItems', 'ground', 'fast', 4);
+            let serverLagActionsLeft = 4;
+            for (const itemId of itemsOnGround) {
+                Orion.MoveItem(itemId, 0, 'myLootBag');
+                Orion.Wait(serverLagActionsLeft ? 50 : 350);
+                serverLagActionsLeft--;
+            }
+        }
+
+        /**
+         * Loot konkretnej mrtvoly
+         *
+         * @param corpseId string - serial mrtvoly
+         * @param cut boolean - rezat?
+         * @param weapon boolean - pouzivat zbran na rezanie?
+         */
+        static lootCorpseId(corpseId: string, cut?: boolean, weapon?: boolean) {
+            let serverLagActionsLeft = 4;
+            Orion.OpenContainer(corpseId, 5000, `Container id ${corpseId} not found`);
+
+            const hasLootBag = Orion.Count('0x0E76', '0x049A', corpseId) > 0;
+            if (hasLootBag && cut) {
+                Orion.UseObject('cutWeapon');
+                Orion.WaitForTarget(1000);
+                Orion.TargetObject(corpseId);
+                if (weapon) {
+                    Orion.UseObject('fightWeapon');
+                    Orion.WaitForTarget(1000) && Orion.CancelTarget();
+                }
+                Orion.Wait(250);
+            }
+
+            const itemsInCorpse = Orion.FindList('lootItems', corpseId);
+            if (itemsInCorpse.length) {
+                for (const itemId of itemsInCorpse) {
+                    // TODO doresit prehazeni veci z hlavniho baglu do myLootBag pri lotovani pytliku
+                    Orion.MoveItem(itemId, 0, 'myLootBag');
+                    Orion.Wait(serverLagActionsLeft ? 150 : 500);
+                    serverLagActionsLeft--;
+                }
+            }
+        }
+
+        /**
+         * Vrati array serialov veci v zakladnom batohu
+         *
+         * @returns string[]
+         */
+        private static getBagSnapshot(): string[] {
+            return Orion.FindType(-1, -1, 'backpack', 'item', undefined, undefined, false);
+        }
+
+        /**
+         * Presunie veci do loot bagu
+         *
+         * @param oldSnapshot - array serialov na ignorovanie
+         */
+        private static moveLootToLootBag(oldSnapshot: string[]) {
+            this.getBagSnapshot()
+                .filter((serial) => oldSnapshot.indexOf(serial) < 0)
+                .forEach((serial, i) => {
+                    Orion.MoveItem(serial, 0, LOOT_BAG);
+                    Orion.Wait(i > 4 ? 500 : 250);
+                });
+        }
+
+        /**
+         * Zobrazenie lootnuteho itemu nad hlavou
+         */
+        private static displayLoot() {
+            const excludes = [
+                'Loot',
+                'gold coins',
+
+                'Black Pearlss',
+                'Ginsengs',
+                'Sulfurous Ashs',
+                'Nightshades',
+                'Garlics',
+                'Blood Mosss',
+                "Spider's Silk",
+                "Spider's Silks",
+                'Mandrake Rootss',
+
+                "Serpent's Scales",
+                'Brimstones',
+                'Boness',
+                'Eyes of Newts',
+                "Wyrm's Heartss",
+                'Volcanic Ashs',
+                "Executioner's Caps",
+                'Fertile Dirts',
+                'Blackmoors',
+                'Pumices',
+                'Obsidians',
+                'Bloodspawns',
+                'Daemon Bloods',
+                'Daemon Boness',
+                "Serpent's Scaless",
+                'Batwingss',
+                "Dragon's Bloods",
+            ];
+
+            const aliases = {
+                'Ancient Bone Helmet': '+5 Necro Helm',
+                'Ancient Bone Arms': '+5 Necro Arms',
+                'Ancient Bone Gloves': '+5 Necro Gloves',
+                'Ancient Bone Leggins': '+5 Necro Legs',
+                'Ancient Bone Chest': '+5 Necro Chest',
+                'Ancient Skeleton Helmet': '+15 Necro Helm',
+                'Ancient Skeleton Arms': '+15 Necro Arms',
+                'Ancient Skeleton Gloves': '+15 Necro Gloves',
+                'Ancient Skeleton Leggins': '+15 Necro Legs',
+                'Ancient Skeleton Chest': '+15 Necro Chest',
+                'Ancient Liche Helmet': '+25 Necro Helm',
+                'Ancient Liche Arms': '+25 Necro Arms',
+                'Ancient Liche Gloves': '+25 Necro Gloves',
+                'Ancient Liche Leggins': '+25 Necro Legs',
+                'Ancient Liche Chest': '+25 Necro Chest',
+            };
+
+            const parseLootItem = (itemName: string) => {
+                const types = {
+                    'of Ruin': '+1',
+                    'of Might': '+3',
+                    'of Force': '+5',
+                    'of Power': '+7',
+                    'of Vanquishing': '+9',
+                    'of Defense': '+5',
+                    'of Guarding': '+10',
+                    'of Hardening': '+15',
+                    'of Fortification': '+20',
+                    'of Invulnerability': '+25',
+                };
+
+                for (const suffix in types) {
+                    if (itemName.indexOf(suffix) > 0) {
+                        return `${types[suffix]} ${itemName.replace(suffix, '')}`;
+                    }
+                }
+
+                return itemName;
+            };
+
+            for (let i = 0; Orion.JournalLine(i); i++) {
+                const lootText = Orion.JournalLine(i).Text();
+                if (lootText.indexOf('You put the') == 0) {
+                    const loot = lootText.replace('You put the ', '').replace(' in your pack.', '');
+                    if (loot.length && excludes.indexOf(loot) < 0) {
+                        const displayLoot = aliases[loot] || parseLootItem(loot);
+                        Scripts.Utils.playerPrint(displayLoot, ColorEnum.green);
+
+                        if (displayLoot === 'Dark Chest of Wonders') {
+                            Orion.UseType('0x0E80', '0x0123');
+                            Orion.Wait(100);
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/scripts/loot.ts
+++ b/src/scripts/loot.ts
@@ -98,21 +98,19 @@ namespace Scripts {
         /**
          * Loot mrtvol okolo v radiuse 2 policka
          */
-        private static lootCorpsesAround(cut?: boolean, weapon?: boolean) {
+        private static lootCorpsesAround(cut?: boolean) {
             let listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
             const LHand = Orion.ObjAtLayer(1);
             const RHand = Orion.ObjAtLayer(2);
             while (listOfCorpses.length) {
                 for (const id of listOfCorpses) {
-                    Scripts.Loot.lootCorpseId(id, cut, weapon);
+                    Scripts.Loot.lootCorpseId(id, cut);
                     Orion.Ignore(id);
                     Orion.Wait(100);
                 }
                 listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
             }
-            if (weapon) {
-                Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
-            }
+            Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
 
             const itemsOnGround = Orion.FindList('lootItems', 'ground', 'fast', 4);
             this.grabItems(itemsOnGround);
@@ -125,18 +123,15 @@ namespace Scripts {
          * @param cut boolean - rezat?
          * @param weapon boolean - pouzivat zbran na rezanie?
          */
-        static lootCorpseId(corpseId: string, cut?: boolean, weapon?: boolean) {
+        static lootCorpseId(corpseId: string, cut?: boolean) {
             Orion.OpenContainer(corpseId, 5000, `Container id ${corpseId} not found`);
 
             const hasLootBag = Orion.Count('0x0E76', '0x049A', corpseId) > 0;
             if (hasLootBag && cut) {
                 if (Orion.FindObject('cutWeapon')) {
+                    Orion.CancelWaitTarget();
+                    Orion.WaitTargetObject(corpseId);
                     Orion.UseObject('cutWeapon');
-                    Orion.WaitForTarget(1000);
-                    Orion.TargetObject(corpseId);
-                } else if (weapon) {
-                    Orion.UseObject('fightWeapon');
-                    Orion.WaitForTarget(1000) && Orion.CancelTarget();
                 }
                 Orion.Wait(250);
             }

--- a/src/scripts/loot.ts
+++ b/src/scripts/loot.ts
@@ -100,6 +100,8 @@ namespace Scripts {
          */
         private static lootCorpsesAround(cut?: boolean, weapon?: boolean) {
             let listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
+            const LHand = Orion.ObjAtLayer(1);
+            const RHand = Orion.ObjAtLayer(2);
             while (listOfCorpses.length) {
                 for (const id of listOfCorpses) {
                     Scripts.Loot.lootCorpseId(id, cut, weapon);
@@ -107,6 +109,9 @@ namespace Scripts {
                     Orion.Wait(100);
                 }
                 listOfCorpses = Orion.FindType('0x2006', '-1', 'ground', 'fast', 2, 'red');
+            }
+            if (weapon) {
+                Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
             }
 
             const itemsOnGround = Orion.FindList('lootItems', 'ground', 'fast', 4);
@@ -125,17 +130,13 @@ namespace Scripts {
 
             const hasLootBag = Orion.Count('0x0E76', '0x049A', corpseId) > 0;
             if (hasLootBag && cut) {
-                Orion.UseObject('cutWeapon');
-                Orion.WaitForTarget(1000);
-                Orion.TargetObject(corpseId);
-                if (weapon) {
-                    const LHand = Orion.ObjAtLayer(1);
-                    const RHand = Orion.ObjAtLayer(2);
-
+                if (Orion.FindObject('cutWeapon')) {
+                    Orion.UseObject('cutWeapon');
+                    Orion.WaitForTarget(1000);
+                    Orion.TargetObject(corpseId);
+                } else if (weapon) {
                     Orion.UseObject('fightWeapon');
                     Orion.WaitForTarget(1000) && Orion.CancelTarget();
-
-                    Scripts.Dress.equip([LHand.Serial(), RHand.Serial()]);
                 }
                 Orion.Wait(250);
             }

--- a/src/scripts/loot.ts
+++ b/src/scripts/loot.ts
@@ -110,12 +110,7 @@ namespace Scripts {
             }
 
             const itemsOnGround = Orion.FindList('lootItems', 'ground', 'fast', 4);
-            let serverLagActionsLeft = 4;
-            for (const itemId of itemsOnGround) {
-                Orion.MoveItem(itemId, 0, 'myLootBag');
-                Orion.Wait(serverLagActionsLeft > 0 ? 50 : 350);
-                serverLagActionsLeft--;
-            }
+            this.grabItems(itemsOnGround);
         }
 
         /**
@@ -126,7 +121,6 @@ namespace Scripts {
          * @param weapon boolean - pouzivat zbran na rezanie?
          */
         static lootCorpseId(corpseId: string, cut?: boolean, weapon?: boolean) {
-            let serverLagActionsLeft = 4;
             Orion.OpenContainer(corpseId, 5000, `Container id ${corpseId} not found`);
 
             const hasLootBag = Orion.Count('0x0E76', '0x049A', corpseId) > 0;
@@ -143,12 +137,16 @@ namespace Scripts {
 
             const itemsInCorpse = Orion.FindList('lootItems', corpseId);
             if (itemsInCorpse.length) {
-                for (const itemId of itemsInCorpse) {
-                    // TODO doresit prehazeni veci z hlavniho baglu do myLootBag pri lotovani pytliku
-                    Orion.MoveItem(itemId, 0, 'myLootBag');
-                    Orion.Wait(serverLagActionsLeft > 0 ? 150 : 500);
-                    serverLagActionsLeft--;
-                }
+                this.grabItems(itemsInCorpse);
+            }
+        }
+
+        private static grabItems(serials: string[]) {
+            let serverLagActionsLeft = 4;
+            for (const serial of serials) {
+                Orion.MoveItem(serial, 0, 'myLootBag');
+                Orion.Wait(serverLagActionsLeft > 0 ? 150 : 500);
+                serverLagActionsLeft--;
             }
         }
 

--- a/src/scripts/statusbar.ts
+++ b/src/scripts/statusbar.ts
@@ -150,8 +150,8 @@ namespace Scripts {
             const currentColor = poisoned ? '#00FF00' : Scripts.Utils.determineHpColorRGB((current * 100) / lineLength);
 
             gump.AddText(10, 25, '0', `${hp}/${max}`, 0, 201);
-            gump.AddColoredPolygone(89, 35, 72, 10, "black")
-            gump.AddColoredPolygone(90, 35, over ? lineLength : current, 10, currentColor)
+            gump.AddColoredPolygone(89, 35, 72, 10, 'black');
+            gump.AddColoredPolygone(90, 35, over ? lineLength : current, 10, currentColor);
         }
     }
 }

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -220,7 +220,7 @@ namespace Scripts {
         }
 
         static playerPrint(message: string, color: ColorEnum | number | string = ColorEnum.none, fastPrint = false) {
-            Utils.charPrint(Player.Serial(), message, color);
+            Utils.charPrint(Player.Serial(), message, color, fastPrint);
         }
 
         static charPrint(


### PR DESCRIPTION
Pridané nové features do lootu
- `_addLootBag` na nastavenie loot pytlika
- presun lootu do lootbagu na základe snapshotov batohu
- už by nemal rezať mrtvoly hráčov.. mrtvolu reže len v prípade, že sa v nej nenachádza oranžový pytlík s lootom
- loot zo zeme (elementi, humani po kuchnutí, ...)
- v prípade, že niečo lootnete (okrem regov, gp, ...), tak to nad hlavou vypíše a nemusíte to hľadať v system message

Fixes:
`Utils.playerPrint` neposúval parameter `fastPrint` nižšie. 