### PR TITLE
Fix issue with status bar line rendering

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -257,7 +257,7 @@ declare namespace Scripts {
 }
 declare namespace Scripts {
     class Statusbar {
-        static create(): void;
+        static create(targetSerial?: string): void;
         static updateStatusbars(): void;
         static updateStatusBarGumpForObject(o: GameObject, s: any, gump: CustomGumpObject, forceUpdate?: boolean): void;
         static drawBody(gump: CustomGumpObject, notoriety?: number, dead?: boolean): void;

--- a/dist/index.js
+++ b/dist/index.js
@@ -4916,9 +4916,11 @@ var Scripts;
     var Statusbar = (function () {
         function Statusbar() {
         }
-        Statusbar.create = function () {
-            Scripts.Utils.createGameObjectSelections([{ ask: 'Target mobile', addObject: 'lastCustomStatusBar' }]);
-            var o = Orion.FindObject('lastCustomStatusBar');
+        Statusbar.create = function (targetSerial) {
+            if (targetSerial === undefined) {
+                Scripts.Utils.createGameObjectSelections([{ ask: 'Target mobile', addObject: 'lastCustomStatusBar' }]);
+            }
+            var o = Orion.FindObject(targetSerial !== null && targetSerial !== void 0 ? targetSerial : 'lastCustomStatusBar');
             var serial = o.Serial();
             var name = o.Name();
             var max = o.MaxHits();
@@ -5027,9 +5029,8 @@ var Scripts;
             var over = hp > max;
             var currentColor = poisoned ? '#00FF00' : Scripts.Utils.determineHpColorRGB(current * 100 / lineLength);
             gump.AddText(10, 25, '0', hp + "/" + max, 0, 201);
-            gump.AddLine(89, 35, 161, 35, 'black', 10, 101);
-            gump.AddLine(90, 35, (over ? lineLength : current) + 90, 35, currentColor, 8, 102);
-            gump.AddText(152, 25, '0', over ? "<basefont size='small' color='red'>+</basefont>" : ' ', 0, 103);
+            gump.AddColoredPolygone(89, 35, 72, 10, "black");
+            gump.AddColoredPolygone(90, 35, over ? lineLength : current, 10, currentColor);
         };
         return Statusbar;
     }());

--- a/src/scripts/statusbar.ts
+++ b/src/scripts/statusbar.ts
@@ -141,9 +141,8 @@ namespace Scripts {
             let currentColor = poisoned ? '#00FF00' : Scripts.Utils.determineHpColorRGB(current * 100 / lineLength);
 
             gump.AddText(10, 25, '0', `${hp}/${max}`, 0, 201);
-            gump.AddLine(89, 35, 161, 35, 'black', 10, 101);
-            gump.AddLine(90, 35, (over ? lineLength : current) + 90, 35, currentColor, 8, 102);
-            gump.AddText(152, 25, '0', over ? "<basefont size='small' color='red'>+</basefont>" : ' ', 0, 103);
+            gump.AddColoredPolygone(89, 35, 72, 10, "black")
+            gump.AddColoredPolygone(90, 35, over ? lineLength : current, 10, currentColor)
         }
 
     }


### PR DESCRIPTION
Všetko až na plusko, ktoré bolo odstránené by malo byť spätne kompatibilné. Dôvod odstránenia pluska bol kvôli tomu, že to vytváralo hluchý priestor napravo od statusbaru, takže ak si mal niečo napravo od statusbaru, tak ti to ten statusbar prekryl a nešlo na to klikať.. 