### PR TITLE
Potion fix

### DIFF
--- a/src/private-exec.ts
+++ b/src/private-exec.ts
@@ -43,7 +43,7 @@ function customStatusBarCallBack(s: string) {
     const code = CustomGumpResponse.ReturnCode();
     const serial: string = <string>(<any>s.toString)(16);
     if (code === CustomStatusBarEnum.close) {
-        Shared.AddVar(s, false);
+        Scripts.Statusbar.close(serial);
     } else if (code === CustomStatusBarEnum.click) {
         if (Orion.HaveTarget()) {
             Orion.TargetObject(serial);

--- a/src/scripts/potions.ts
+++ b/src/scripts/potions.ts
@@ -41,8 +41,18 @@ namespace Scripts {
                 return;
             }
 
+            let potion = null;
             const p = gameObject.potions[potionName];
-            let potion = Scripts.Utils.findFirstType(p);
+            const kad = Scripts.Utils.findFirstType(p.kad);
+            
+            if (kad) {
+                const types = Orion.FindType(p.graphic, p.color);
+                if (types && types.length > 0) {
+                    potion = types[0];
+                }
+            } else {
+                potion = Scripts.Utils.findFirstType(p);
+            }
 
             if (!potion) {
                 // docepnuti

--- a/src/scripts/statusbar.ts
+++ b/src/scripts/statusbar.ts
@@ -46,6 +46,31 @@ namespace Scripts {
             Scripts.Statusbar.updateStatusBarGumpForObject(mobile, statusBar, gump, true);
         }
 
+        static close(serial:string, gump?:CustomGumpObject) {
+            const statusBars = Shared.GetArray(GlobalEnum.customStatusBars, []);
+            const mobileKey = `${TimersEnum.statusBarTimer}_${serial}`;
+            Shared.AddVar(serial, false);
+            Orion.RemoveTimer(mobileKey);
+            Shared.AddVar(serial, false);
+
+            gump = gump ?? Orion.CreateCustomGump(parseInt(serial, 16));
+            gump?.Clear();
+            gump?.Close();
+
+            for (let i = statusBars.length - 1; i > -1; i--) {
+                if (statusBars[i].serial === serial) {
+                    statusBars.splice(i, 1);
+                }
+            }
+            Shared.AddArray(GlobalEnum.customStatusBars, statusBars);
+        }
+
+        static exists(serial:string) {
+            const statusBars = Shared.GetArray(GlobalEnum.customStatusBars, []);
+            const exists = Shared.GetVar(serial, false)
+            return exists && statusBars.some(a=>a.serial === serial);
+        }
+
         static updateStatusbars() {
             const statusBars = Shared.GetArray(GlobalEnum.customStatusBars, []);
 
@@ -67,7 +92,6 @@ namespace Scripts {
                     Scripts.Statusbar.redrawBodyToNoObject(statusBar, gump);
                 }
             }
-
             Shared.AddArray(GlobalEnum.customStatusBars, statusBars);
         }
 
@@ -76,14 +100,11 @@ namespace Scripts {
             const mobileKey = `${TimersEnum.statusBarTimer}_${statusBar.serial}`;
             const timerExists = Orion.TimerExists(mobileKey);
 
-            if (statusBar.autoCloseTimer && !mobile) {
+            if (statusBar.autoCloseTimer && statusBar.autoCloseTimer > 0 && !mobile) {
                 if (!timerExists) {
                     Orion.SetTimer(mobileKey);
                 } else if (Orion.Timer(mobileKey) > statusBar.autoCloseTimer) {
-                    Orion.RemoveTimer(mobileKey);
-                    Shared.AddVar(statusBar.serial, false);
-                    gump.Clear();
-                    gump.Close();
+                    Scripts.Statusbar.close(statusBar.serial, gump);
                     return true;
                 }
             } else if (timerExists) {
@@ -94,11 +115,15 @@ namespace Scripts {
 
         static resolveIndicators(mobile:GameObject):any[]  { 
             const targetIndicators = config?.statusBar?.targetIndicators ?? [];
+            const result = [];
             for (const indicator of targetIndicators) {
+                let clone =  { targetAlias: { alias: indicator.targetAlias?.alias }, color: indicator.color, active: false  };
                 const targetResult = TargetingEx.resolveTraget([ <ITargetAlias>indicator.targetAlias ]);
-                indicator.active = mobile && mobile.Serial() && targetResult.isValid() && mobile.Serial() === targetResult.gameObject()?.Serial();
+
+                clone.active = mobile && mobile.Serial() && targetResult.isValid() && mobile.Serial() === targetResult.gameObject()?.Serial();
+                result.push(clone);
             }
-            return targetIndicators;
+            return result;
         }        
 
         static resolveActiveIndicators(statusBar:any):any[]  { 
@@ -112,6 +137,9 @@ namespace Scripts {
         }
 
         static indicatorChanged(statusBar:any, indicators:any[]):boolean {
+            if (!indicators || indicators.length <= 0) {
+                return true;
+            }
             return statusBar.targetIndicators.some(a=>indicators.some(b=>b.targetAlias.alias===a.targetAlias.alias && b.active !== a.active));
         }
 

--- a/src/scripts/targeting.ts
+++ b/src/scripts/targeting.ts
@@ -352,11 +352,9 @@ namespace Scripts {
                 }
 
                 if (custBars) {
-                    const bars = Shared.GetArray(GlobalEnum.customStatusBars, []);
-                    const exists =
-                        bars && bars.some((s) => s.serial === barObj.Serial() && Shared.GetVar(s.serial, true));
+                    const exists = Scripts.Statusbar.exists(serial);
                     if (!exists) {
-                        Statusbar.create(Orion.FindObject(serial), {
+                        Statusbar.create(serial, {
                             x: startX + deltaX * (count % maxCount),
                             y: startY + deltaY * (count % maxCount),
                         }, config?.statusBarWrapper?.autoCloseTimer);


### PR DESCRIPTION
Drobna zmena piti potek. findFirsType je super metoda, ale spis je predpoklad ze halucinace nemam a aby to zbytecne neproklikavalo nekdy i 15 potek (napr grafika invisky vs GS), tak hledam type standardne az nasledne jedu findFirstType a fill.
Aby to fungovalo porad stejne je tam check na kad (PvP nebo potky kde u kterych kad nemam nebo mam haluze, kad neni...).